### PR TITLE
Add Kubernetes End-to-End Testing Using Testcontainers and Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ Discover official and community modules from the [Modules Catalog](https://testc
 ## Testcontainers and Kubernetes
 
 - [Kindcontainers](https://github.com/dajudge/kindcontainer)
-- [Develop Kubernetes Operators in Java without Breaking a Sweat](https://www.docker.com/blog/develop-kubernetes-operators-in-java-without-breaking-a-sweat/) ![badge](https://img.shields.io/badge/-new-green) 
+- [Develop Kubernetes Operators in Java without Breaking a Sweat](https://www.docker.com/blog/develop-kubernetes-operators-in-java-without-breaking-a-sweat/) ![badge](https://img.shields.io/badge/-new-green)
+- [Kubernetes End-to-End Testing Using Testcontainers and Python](https://thenewstack.io/kubernetes-end-to-end-testing-using-testcontainers-and-python/)
 
 ## Testcontainers and .NET
 


### PR DESCRIPTION
This PR adds recently published blog titled "Kubernetes End-to-End Testing Using Testcontainers and Python" 